### PR TITLE
disable calling debugUpdate() in update

### DIFF
--- a/GCam.lua
+++ b/GCam.lua
@@ -461,8 +461,9 @@ function GCam:update(dt)
 		if self.x ~= dstX or self.y ~= dstY then 
 			self:goto(dstX,dstY)
 		end
-		
-		self:debugUpdate(true,x,y)
+
+		-- debug
+		if self.__debug__ then self:debugUpdate(true,x,y) end
 		
 	end
 	self:updateClip()


### PR DESCRIPTION
When set debug to false, update() still calls debugUpdate() in our game, which eats resources:

13	100%	426	onEnterFrame	@scenes/levelX.lua:55:000002e4af48a5a0 [5]	13	28%	426	update	@classes/gcamV2debug.lua:449:000002e4af4757d0
	1	7%	426	getPosition	=[C] 00007ff7aa673cf0(getPosition)
	0	**3%	426	debugUpdate	@classes/gcamV2debug.lua:305:000002e4af475c50**
	3	25%	426	rectangle	@classes/gcamV2debug.lua:359:000002e4af475aa0
	5	38%	426	goto	@classes/gcamV2debug.lua:738:000002e4af4741e0

This commit should fix the issue.